### PR TITLE
fix: add types declaration of /client entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "url": "git+https://github.com/dishait/vite-plugin-vue-meta-layouts.git"
   },
   "exports": {
+    "./client": {
+      "types": "./client.d.ts"
+    },
     "./*": "./*",
     ".": {
       "require": "./dist/index.cjs",


### PR DESCRIPTION
The solution to declaration error is to declare types entry in package.json for `/client` entry

resolves #9