### PR TITLE
fix: 更新 setupLayouts 的类型定义，使用 RouterOptions['routes']

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -2,12 +2,12 @@ declare module "virtual:meta-layouts" {
   import type {
     Router,
     RouteRecordNormalized,
-    RouteRecordRaw,
+    RouterOptions,
   } from "vue-router";
 
   export const setupLayouts: (
-    routes: RouteRecordRaw[],
-  ) => RouteRecordRaw[];
+    routes: RouterOptions['routes'],
+  ) => RouterOptions['routes'];
 
   export const createGetRoutes: (
     router: Router,


### PR DESCRIPTION
fix:
```bash
src/plugins/router-plugin.ts:7:41 - error TS2345: Argument of type 'readonly RouteRecordRaw[]' is not assignable to parameter of type 'RouteRecordRaw[]'.
  The type 'readonly RouteRecordRaw[]' is 'readonly' and cannot be assigned to the mutable type 'RouteRecordRaw[]'.

7 const setupLayoutsResult = setupLayouts(routes);
                                          ~~~~~~


Found 1 error.

 ELIFECYCLE  Command failed with exit code 2.
```



<img width="739" height="550" alt="image" src="https://github.com/user-attachments/assets/775f31d5-dbc6-4e33-8e81-4cb43fe0e30d" />


<img width="666" height="520" alt="image" src="https://github.com/user-attachments/assets/d0840622-82a0-415c-9be1-d04aecee6a66" />


`npm pack`了一个，安装测试没有问题。
vite-plugin-vue-meta-layouts-0.6.0.tgz

[vite-plugin-vue-meta-layouts-0.6.0.tgz](https://github.com/user-attachments/files/22998317/vite-plugin-vue-meta-layouts-0.6.0.tgz)

